### PR TITLE
Fix application generated in "undefined" directory

### DIFF
--- a/src/application/index.ts
+++ b/src/application/index.ts
@@ -14,8 +14,16 @@ export default function (options: ApplicationOptions): Rule {
 }
 
 function renderTemplate(options: ApplicationOptions): Rule {
-  const path = options.directory || options.name
+  const path = targetDirectory(options)
   return mergeWith(
     apply(url("./files"), [template({ ...options }), move(path)]),
   )
+}
+
+function targetDirectory(options: ApplicationOptions): string {
+  if (options.directory && options.directory !== "undefined") {
+    return options.directory
+  } else {
+    return options.name
+  }
 }


### PR DESCRIPTION
When the `--directory` option is not present, its value becomes the string `"undefined"` instead of really being undefined.